### PR TITLE
Improve processCcd output

### DIFF
--- a/config/characterise.py
+++ b/config/characterise.py
@@ -1,26 +1,22 @@
-'''
-Override the default characterise config parameters by putting them in here.
-e.g.:
-config.doWrite = False
-'''
 # Cosmic ray removal
 # See: https://github.com/lsst/meas_algorithms/blob/master/src/CR.cc
 config.repair.doCosmicRay = True
 
-# We seem to be getting too many CR detections
-# For now we can increase the max number of allowable CRs
+# This controls the maximum number of allowable CRs in an image
 config.repair.cosmicray.nCrPixelMax = 1000000
 
-# Raising these numbers reduces the number of CRs
+# Raising this contrast parameter reduces the number of CRs
 config.repair.cosmicray.cond3_fac = 10
-config.repair.cosmicray.cond3_fac2 = 10
 
-# This sets the minimum brightness for a CR.
-config.repair.cosmicray.min_DN = 100000
+# Lowering this contrast parameter reduces the number of CRs
+config.repair.cosmicray.cond3_fac2 = 0
 
-# Sometimes there are no initial source detections, causing errors
-# Lowering this number gives more sources for PSF fitting (default 10)
-config.detection.includeThresholdMultiplier = 5.0
 
-# Try and get PSF fitting to work
-config.psfIterations = 1 #More than this and it fails... not sure why.
+# PSF settings
+# See: https://github.com/lsst/pipe_tasks/blob/master/python/lsst/pipe/tasks/measurePsf.py
+
+# Increasing this number gives a more accurate PSF estimate
+config.psfIterations = 3
+
+# Increasing this number allows more PSF candidates
+config.measurePsf.starSelector['objectSize'].widthStdAllowed = 0.5

--- a/config/characterise.py
+++ b/config/characterise.py
@@ -11,6 +11,13 @@ config.repair.doCosmicRay = True
 # For now we can increase the max number of allowable CRs
 config.repair.cosmicray.nCrPixelMax = 1000000
 
+# Raising these numbers reduces the number of CRs
+config.repair.cosmicray.cond3_fac = 10
+config.repair.cosmicray.cond3_fac2 = 10
+
+# This sets the minimum brightness for a CR.
+config.repair.cosmicray.min_DN = 100000
+
 # Sometimes there are no initial source detections, causing errors
 # Lowering this number gives more sources for PSF fitting (default 10)
 config.detection.includeThresholdMultiplier = 5.0

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,3 +8,5 @@ services:
     volumes:
       - "$OBS_HUNTSMAN:/opt/lsst/software/stack/stack/current/Linux64/obs_huntsman"
       - "$OBS_HUNTSMAN_TESTDATA:/opt/lsst/software/stack/testdata"
+    environment:
+      OBS_HUNTSMAN=/opt/lsst/software/stack/stack/current/Linux64/obs_huntsman

--- a/policy/HuntsmanMapper.yaml
+++ b/policy/HuntsmanMapper.yaml
@@ -6,12 +6,10 @@ defaultLevel: Ccd
 # Even if it were possible and you **only** used the defaults in the obs_base/policy files you still need to include exposures, calibrations, and datasets so that it knows to refer to the defaults in obs_base.
 exposures:
   raw:
-    python: lsst.afw.image.DecoratedImageF
-    persistable: DecoratedImageF
+    python: lsst.afw.image.DecoratedImageU
+    persistable: DecoratedImageU
     template: 'raw/%(dateObs)s/%(dataType)s-%(visit)04d-%(filter)s-%(ccd)02d.fits'
   calexp:
-    python: lsst.afw.image.DecoratedImageF
-    persistable: DecoratedImageF
     template: 'calexp/calexp/%(visit)07d/calexp-%(visit)07d_%(ccd)02d-%(filter)s.fits'
 
 calibrations:


### PR DESCRIPTION
This PR does a few things:

- Modifies some config parameters so that the PSF measurement runs properly
- Modifies some config parameters to reduce the number of CRs
- Adds $OBS_HUNTSMAN to the docker container's environment
- Corrects the data types in the policy file
