### PR TITLE
Astrometric & Photometric calibration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # obs_huntsman
 
 Huntsman-specific configuration and tasks for the LSST Data Management Stack
+
+## Creating and ingesting the astrometry catalogue
+```
+# Prepare the reference catalogue in LSST format
+python $OBS_HUNTSMAN/scripts/ingestSkyMapperReference.py
+
+# Move the ingested catalogue into the desired repo's ref_cats directory
+cd $LSST_HOME
+mkdir DATA/ref_cats
+ln -s testdata/ref_cats/skymapper_test/ref_cats/skymapper_dr3 DATA/ref_cats/
+```

--- a/README.md
+++ b/README.md
@@ -1,14 +1,3 @@
 # obs_huntsman
 
 Huntsman-specific configuration and tasks for the LSST Data Management Stack
-
-## Creating and ingesting the astrometry catalogue
-```
-# Prepare the reference catalogue in LSST format
-python $OBS_HUNTSMAN/scripts/ingestSkyMapperReference.py
-
-# Move the ingested catalogue into the desired repo's ref_cats directory
-cd $LSST_HOME
-mkdir DATA/ref_cats
-ln -s testdata/ref_cats/skymapper_test/ref_cats/skymapper_dr3 DATA/ref_cats/
-```

--- a/config/calibrate.py
+++ b/config/calibrate.py
@@ -7,10 +7,14 @@ Useful info for photocal:
 https://community.lsst.org/t/reference-catalogs-camfluxes-and-colorterms/3578
 https://community.lsst.org/t/pan-starrs-reference-catalog-in-lsst-format/1572
 http://doxygen.lsst.codes/stack/doxygen/x_11_0/load_reference_objects_8py_source.html
+
+For setting up filters:
+https://community.lsst.org/t/failure-finding-flux-fields-in-processeimages-py/2486/2
 '''
 from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
+from lsst.pipe.tasks.colorterms import ColortermDict, Colorterm
 
-REFCAT = "ps1_pv3_3pi_20170110_GmagLT19"
+REFCAT = "skymapper_dr3"
 
 config.astromRefObjLoader.retarget(LoadIndexedReferenceObjectsTask)
 config.astromRefObjLoader.ref_dataset_name = REFCAT
@@ -22,3 +26,23 @@ config.connections.photoRefCat = REFCAT
 
 config.doPhotoCal = False
 config.doAstrometry = True
+
+# These colorterms are for HSC, included as an example
+"""
+colorterms = config.calibrate.photoCal.colorterms
+colorterms.data["ps1*"] = ColortermDict(data={
+    'g': Colorterm(primary="g", secondary="r", c0=0.00730066, c1=0.06508481, c2=-0.01510570),
+    'r': Colorterm(primary="r", secondary="i", c0=0.00279757, c1=0.02093734, c2=-0.01877566),
+    'r2': Colorterm(primary="r", secondary="i", c0=0.00117690, c1=0.00003996, c2=-0.01667794),
+    'i': Colorterm(primary="i", secondary="z", c0=0.00166891, c1=-0.13944659, c2=-0.03034094),
+    'i2': Colorterm(primary="i", secondary="z", c0=0.00180361, c1=-0.18483562, c2=-0.02675511),
+    'z': Colorterm(primary="z", secondary="y", c0=-0.00907517, c1=-0.28840221, c2=-0.00316369),
+    'y': Colorterm(primary="y", secondary="z", c0=-0.00156858, c1=0.14747401, c2=0.02880125),
+})
+"""
+# Specify mappings between Huntsman and Skymapper filters
+for refObjLoader in (config.astromRefObjLoader,
+                     config.photoRefObjLoader,
+                     ):
+    refObjLoader.filterMap['g2'] = 'g_psf'
+    # refObjLoader.filterMap['i2'] = 'i'

--- a/config/calibrate.py
+++ b/config/calibrate.py
@@ -2,6 +2,23 @@
 Override the default calibrate config parameters by putting them in here.
 e.g.:
 config.doAstrometry = False
+
+Useful info for photocal:
+https://community.lsst.org/t/reference-catalogs-camfluxes-and-colorterms/3578
+https://community.lsst.org/t/pan-starrs-reference-catalog-in-lsst-format/1572
+http://doxygen.lsst.codes/stack/doxygen/x_11_0/load_reference_objects_8py_source.html
 '''
+from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
+
+REFCAT = "ps1_pv3_3pi_20170110_GmagLT19"
+
+config.astromRefObjLoader.retarget(LoadIndexedReferenceObjectsTask)
+config.astromRefObjLoader.ref_dataset_name = REFCAT
+config.photoRefObjLoader.retarget(LoadIndexedReferenceObjectsTask)
+config.photoRefObjLoader.ref_dataset_name = REFCAT
+config.photoCal.photoCatName = REFCAT
+config.connections.astromRefCat = REFCAT
+config.connections.photoRefCat = REFCAT
+
 config.doPhotoCal = False
-config.doAstrometry = False
+config.doAstrometry = True

--- a/config/calibrate.py
+++ b/config/calibrate.py
@@ -24,7 +24,7 @@ config.photoCal.photoCatName = REFCAT
 config.connections.astromRefCat = REFCAT
 config.connections.photoRefCat = REFCAT
 
-config.doPhotoCal = False
+config.doPhotoCal = True
 config.doAstrometry = True
 
 # These colorterms are for HSC, included as an example

--- a/config/characterise.py
+++ b/config/characterise.py
@@ -14,10 +14,17 @@ config.repair.cosmicray.cond3_fac2 = 0
 
 # PSF settings
 # See: https://github.com/lsst/pipe_tasks/blob/master/python/lsst/pipe/tasks/measurePsf.py
+# See: http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/object_size_star_selector_8py_source.html
+# See: http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/pca_psf_determiner_8py_source.html
 config.doMeasurePsf = True
+
+# config.measurePsf.doFluxLimit = False
+config.measurePsf.starSelector['objectSize'].doSignalToNoiseLimit = True
+config.measurePsf.starSelector['objectSize'].doFluxLimit = False
+config.measurePsf.starSelector['objectSize'].signalToNoiseMin = 15  # Default 20
 
 # Increasing this number gives a more accurate PSF estimate
 config.psfIterations = 3
 
 # Increasing this number allows more PSF candidates
-config.measurePsf.starSelector['objectSize'].widthStdAllowed = 0.5
+# config.measurePsf.starSelector['objectSize'].widthStdAllowed = 0.5

--- a/config/ingest.py
+++ b/config/ingest.py
@@ -22,7 +22,7 @@ config.parse.translation = {'expTime': 'EXPTIME',
                             'ccdTemp': 'CCD-TEMP',
                             'expId': 'IMAGEID',
                             'taiObs': 'DATE-OBS', #Not sure what this one is
-                            'filter': 'FILTER'
+                            # 'filter': 'FILTER'
                             }
 
 # Specify default key value pairs which are used if FITS keyword is missing
@@ -36,7 +36,8 @@ config.parse.translators = {'visit': 'translate_visit',
                             'dataType': 'translate_dataType',
                             'ccd': 'translate_ccd',
                             'field': 'translate_field',
-                            'expId': 'translate_expId'
+                            'expId': 'translate_expId',
+                            'filter': 'translate_filter'
                             }
 
 # Declare the columns that should be read

--- a/config/ingestSkyMapperReference.py
+++ b/config/ingestSkyMapperReference.py
@@ -1,0 +1,30 @@
+"""
+Documentation:
+https://pipelines.lsst.io/modules/lsst.meas.algorithms/creating-a-reference-catalog.html
+https://pipelines.lsst.io/modules/lsst.meas.algorithms/tasks/lsst.meas.algorithms.IngestIndexedReferenceTask.html#lsst-meas-algorithms-ingestindexedreferencetask-configs
+"""
+# The name of the output reference catalog dataset.
+config.dataset_config.ref_dataset_name = "skymapper_dr3"
+
+# Gen3 butler wants all of our refcats have the same indexing depth.
+config.dataset_config.indexer['HTM'].depth = 7
+
+# Ingest the data in parallel with this many processes.
+config.n_processes = 8
+
+# These define the names of the fields from the gaia_source data model:
+# http://skymapper.anu.edu.au/table-browser/
+
+config.id_name = "object_id"
+config.ra_name = "raj2000"
+config.dec_name = "dej2000"
+config.ra_err_name = "e_raj2000"
+config.dec_err_name = "e_dej2000"
+
+# All or none of these should be set
+# config.epoch_name = "mean_epoch"
+# config.epoch_format = "mjd"
+# config.epoch_scale = ???
+
+config.mag_column_list = ["u_psf", "g_psf", "r_psf", "i_psf", "z_psf"]
+config.mag_err_column_map = {s: f"e_{s}" for s in config.mag_column_list}

--- a/config/makeDiscreteSkyMap.py
+++ b/config/makeDiscreteSkyMap.py
@@ -5,7 +5,10 @@ Config for the makeDiscreteSkyMapTask.
 config.coaddName='deep'
 
 # dimensions of inner region of patches (x,y pixels)
-config.skyMap.patchInnerDimensions=[10000, 10000]
+config.skyMap.patchInnerDimensions=[5000, 5000]
+
+# nominal pixel scale (arcsec/pixel)
+config.skyMap.pixelScale = 3
 
 # border between patch inner and outer bbox (pixels)
 config.skyMap.patchBorder=100

--- a/config/makeDiscreteSkyMap.py
+++ b/config/makeDiscreteSkyMap.py
@@ -5,7 +5,7 @@ Config for the makeDiscreteSkyMapTask.
 config.coaddName='deep'
 
 # dimensions of inner region of patches (x,y pixels)
-config.skyMap.patchInnerDimensions=[4000, 4000]
+config.skyMap.patchInnerDimensions=[10000, 10000]
 
 # border between patch inner and outer bbox (pixels)
 config.skyMap.patchBorder=100

--- a/config/makeDiscreteSkyMap.py
+++ b/config/makeDiscreteSkyMap.py
@@ -1,0 +1,14 @@
+"""
+Config for the makeDiscreteSkyMapTask.
+"""
+# coadd name, e.g. deep, goodSeeing, chiSquared
+config.coaddName='deep'
+
+# dimensions of inner region of patches (x,y pixels)
+config.skyMap.patchInnerDimensions=[4000, 4000]
+
+# border between patch inner and outer bbox (pixels)
+config.skyMap.patchBorder=100
+
+# minimum overlap between adjacent sky tracts, on the sky (deg)
+config.skyMap.tractOverlap=0.0

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,7 +11,7 @@ Then:
 cd $OBS_HUNTSMAN/docker
 docker-compose run lsst_stack
 ```
-### Ingesting images
+### Ingest raw science and calibration images (raw)
 
 ```
 cd $LSST_HOME
@@ -21,20 +21,41 @@ ingestImages.py DATA testdata/calib/*.fits.fz --mode=link --calib DATA/CALIB
 
 Note here that since we are using raw (i.e. not master) calibration files, we use `ingestImages.py` here. If they were master calibration frames, `ingestCalibs.py` should be used instead.
 
-### Ingest the astrometry/photometry reference catalogue
+## Create and ingest the astrometry catalogue (refcat)
+
 ```
+# Prepare the reference catalogue in LSST format
+python $OBS_HUNTSMAN/scripts/ingestSkyMapperReference.py
+
+# Move the ingested catalogue into the desired repo's ref_cats directory
+cd $LSST_HOME
 mkdir DATA/ref_cats
 ln -s $LSST_HOME/testdata/ref_cats/skymapper_test/ref_cats/skymapper_dr3 DATA/ref_cats/
 ```
 
-## Create & ingest master calibration frames
+## Create & ingest master calibration images (biases, flats)
 ```
 python $OBS_HUNTSMAN/scripts/constructHuntsmanBiases.py 2018-05-16
 python $OBS_HUNTSMAN/scripts/constructHuntsmanBiases.py 2018-08-06
 python $OBS_HUNTSMAN/scripts/constructHuntsmanFlats.py 2018-05-16
 ```
 
-## Process the data
+## Process the data to produce calibrated images (calexps)
 ```
 processCcd.py DATA --rerun processCcdOutputs --calib DATA/CALIB --id dataType=science
+```
+
+## Make a SkyMap
+```
+makeDiscreteSkyMap.py DATA --id --rerun processCcdOutputs:coadd
+```
+
+## Warp calexps onto the SkyMap
+```
+makeCoaddTempExp.py DATA --rerun coadd --selectId filter=g2_8 --id filter=g2_8 tract=0 patch=0,0^0,1^0,2^1,0^1,1^1,2^2,0^2,1^2,2 --config doApplyUberCal=False
+```
+
+## Make the coadds
+```
+assembleCoadd.py DATA --rerun coadd --selectId filter=g2_8 --id filter=g2_8 tract=0 patch=0,0^0,1^0,2^1,0^1,1^1,2^2,0^2,1^2,2
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,6 +14,7 @@ docker-compose run lsst_stack
 ### Ingesting images
 
 ```
+cd $LSST_HOME
 ingestImages.py DATA testdata/science/*.fits --mode=link --calib DATA/CALIB
 ingestImages.py DATA testdata/calib/*.fits.fz --mode=link --calib DATA/CALIB
 ```
@@ -22,8 +23,8 @@ Note here that since we are using raw (i.e. not master) calibration files, we us
 
 ### Ingest the astrometry/photometry reference catalogue
 ```
-mdkir DATA/ref_cats
-ln -s $LSST_HOME/testdata/ref_cats/ps1_pv3_3pi_20170110_GmagLT19 DATA/ref_cats/
+mkdir DATA/ref_cats
+ln -s $LSST_HOME/testdata/ref_cats/skymapper_test/ref_cats/skymapper_dr3 DATA/ref_cats/
 ```
 
 ## Create & ingest master calibration frames

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,6 +20,12 @@ ingestImages.py DATA testdata/calib/*.fits.fz --mode=link --calib DATA/CALIB
 
 Note here that since we are using raw (i.e. not master) calibration files, we use `ingestImages.py` here. If they were master calibration frames, `ingestCalibs.py` should be used instead.
 
+### Ingest the astrometry/photometry reference catalogue
+```
+mdkir DATA/ref_cats
+ln -s $LSST_HOME/testdata/ref_cats/ps1_pv3_3pi_20170110_GmagLT19 DATA/ref_cats/
+```
+
 ## Create & ingest master calibration frames
 ```
 python $OBS_HUNTSMAN/scripts/constructHuntsmanBiases.py 2018-05-16

--- a/docker/README.md
+++ b/docker/README.md
@@ -52,10 +52,10 @@ makeDiscreteSkyMap.py DATA --id --rerun processCcdOutputs:coadd
 
 ## Warp calexps onto the SkyMap
 ```
-makeCoaddTempExp.py DATA --rerun coadd --selectId filter=g2_8 --id filter=g2_8 tract=0 patch=0,0^0,1^0,2^1,0^1,1^1,2^2,0^2,1^2,2 --config doApplyUberCal=False
+makeCoaddTempExp.py DATA --rerun coadd --selectId filter=g2 --id filter=g2 tract=0 patch=0,0^0,1^0,2^1,0^1,1^1,2^2,0^2,1^2,2 --config doApplyUberCal=False
 ```
 
 ## Make the coadds
 ```
-assembleCoadd.py DATA --rerun coadd --selectId filter=g2_8 --id filter=g2_8 tract=0 patch=0,0^0,1^0,2^1,0^1,1^1,2^2,0^2,1^2,2
+assembleCoadd.py DATA --rerun coadd --selectId filter=g2 --id filter=g2 tract=0 patch=0,0^0,1^0,2^1,0^1,1^1,2^2,0^2,1^2,2
 ```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,3 +10,9 @@ services:
       - "$OBS_HUNTSMAN_TESTDATA:/opt/lsst/software/stack/testdata"
     environment:
       - OBS_HUNTSMAN=/opt/lsst/software/stack/stack/current/Linux64/obs_huntsman
+  lsst_firefly:
+    image: ipac/firefly:lsst-dev
+    ports:
+      - "8080:8080"
+    environment:
+      - "MAX_JVM_SIZE=8G"

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -26,10 +26,15 @@ RUN cd $LSST_HOME && \
   mkdir DATA && \
   mkdir DATA/CALIB && \
   echo "lsst.obs.huntsman.HuntsmanMapper" > DATA/_mapper && \
-  echo "lsst.obs.huntsman.HuntsmanMapper" > DATA/CALIB/_mapper
+  echo "lsst.obs.huntsman.HuntsmanMapper" > DATA/CALIB/_mapper && \
 
-#Make directory for Hunstman obs packge
-RUN mkdir -p $STACK/obs_huntsman
+  #Make directory for Hunstman obs packge
+  mkdir -p $STACK/obs_huntsman && \
+
+  # Install some extra stuff
+  . $LSST_HOME/loadLSST.bash && \
+  pip install ipython
+
 
 ADD ./docker/startup.sh .
 CMD ["sh", "./startup.sh"]

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,4 +1,5 @@
 . $LSST_HOME/loadLSST.bash
 eups declare obs_huntsman v1 -r $STACK/obs_huntsman
 setup obs_huntsman v1
+setup display_firefly
 /bin/bash

--- a/policy/HuntsmanMapper.yaml
+++ b/policy/HuntsmanMapper.yaml
@@ -18,6 +18,9 @@ exposures:
     template: 'calexp/calexp/%(visit)07d/calexp-%(visit)07d_%(ccd)02d-%(filter)s.fits'
   postISRCCD:
     template: 'postISR/postISR/%(visit)07d/postISR-%(visit)07d_%(ccd)02d-%(filter)s.fits'
+  # deepCoadd_directWarps are warped calexps made by makeCoaddTempEx.py
+  deepCoadd_directWarp:
+    template: deepCoadd/%(filter)s/%(tract)d/%(patch)stempExp/v%(visit)d-f%(filter)s.fits
 
 datasets:
   processCcd_metadata:

--- a/policy/HuntsmanMapper.yaml
+++ b/policy/HuntsmanMapper.yaml
@@ -28,6 +28,14 @@ datasets:
     template: 'sci-results/src/%(dateObs)s/src-%(visit)04d-%(filter)s-%(ccd)02d.fits'
   calexpBackground:
     template: 'calexp/bkgd/%(visit)07d/calexp-%(visit)07d_%(ccd)02d-%(filter)s.fits'
+  # srcMatch is the catalogue of sources that matched with the reference catalogue
+  # srcMatch is produced during image calibration
+  srcMatch:
+    persistable: BaseCatalog
+    python: lsst.afw.table.BaseCatalog
+    storage: FitsCatalogStorage
+    tables: raw
+    template: refmatch/srcMatch/%(dateObs)s/srcMatch-%(visit)04d-%(filter)s-%(ccd)02d.fits
 
 calibrations:
   bias:

--- a/python/lsst/obs/huntsman/HuntsmanMapper.py
+++ b/python/lsst/obs/huntsman/HuntsmanMapper.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, division, print_function
-
 import os
 
 from lsst.daf.persistence import Policy
@@ -7,6 +6,8 @@ from lsst.obs.base import CameraMapper
 import lsst.afw.image.utils as afwImageUtils
 import lsst.afw.image as afwImage
 from .makeHuntsmanRawVisitInfo import MakeHuntsmanRawVisitInfo
+from .huntsmanFilters import HUNTSMAN_FILTER_DEFINITIONS
+
 
 class HuntsmanMapper(CameraMapper):
 
@@ -15,16 +16,24 @@ class HuntsmanMapper(CameraMapper):
     # A rawVisitInfoClass is required by processCcd.py
     MakeRawVisitInfoClass = MakeHuntsmanRawVisitInfo
 
+    # Specify the filter definitions
+    filterDefinitions = HUNTSMAN_FILTER_DEFINITIONS
+
     def __init__(self, inputPolicy=None, **kwargs):
 
-        #Declare the policy file...
+        # Declare the policy file
         policyFile = Policy.defaultPolicyFile(self.packageName, "HuntsmanMapper.yaml", "policy")
         policy = Policy(policyFile)
-        #...and add it to the mapper:
+
+        # Add policy to the mapper
         super(HuntsmanMapper, self).__init__(policy, os.path.dirname(policyFile), **kwargs)
 
-        ###Defining your filter set###
-        #Create a python dict of filters:
+        # Define filters
+        self.filterDefinitions.reset()
+        self.filterDefinitions.defineFilters()
+
+        """
+        # Define filters
         self.filters = {}
 
         #Define your set of filters; you can have as many filters as you like...
@@ -35,7 +44,8 @@ class HuntsmanMapper(CameraMapper):
 
         #...and set your default filter.
         self.defaultFilterName = 'Clear'
-        ##############################
+        """
+        
 
     def _computeCcdExposureId(self, dataId):
         '''

--- a/python/lsst/obs/huntsman/huntsmanFilters.py
+++ b/python/lsst/obs/huntsman/huntsmanFilters.py
@@ -1,0 +1,15 @@
+"""
+- lambdaMin and lambdaMax are chosen to be where the filter rises above 1%
+- physical_filter specifies names of individual pieces of glass (1 per filter per lens)
+- abstract_filter is the generic name of the filter
+- See: https://github.com/lsst/obs_base/blob/769a877cad0ce0996a796bb2e0cfcd1832815f13/python/lsst/obs/base/filters.py
+"""
+from lsst.obs.base import FilterDefinition, FilterDefinitionCollection
+
+# Note that these aren't the proper measurements, just guesses for now.
+
+HUNTSMAN_FILTER_DEFINITIONS = FilterDefinitionCollection(
+    FilterDefinition(physical_filter="g2_8",
+                     abstract_filter="g2",
+                     lambdaEff=550, lambdaMin=500, lambdaMax=600),
+)

--- a/python/lsst/obs/huntsman/ingest.py
+++ b/python/lsst/obs/huntsman/ingest.py
@@ -47,6 +47,13 @@ class HuntsmanParseTask(ParseTask):
                                       f"{md['IMAGETYP']}")
         return dataType
 
+    def translate_filter(self, md):
+        """
+        Translate the given filter name to the abstract filter name.
+        For Huntsman, we strip of the serial number.
+        """
+        return "_".join(md["FILTER"].split("_")[:-1])
+
     def translate_visit(self, md):
         '''
         Return integer value corresponding to visit number.
@@ -100,7 +107,7 @@ class HuntsmanParseTask(ParseTask):
             return md['IMAGEID']
         except KeyError:
             return f'{np.random.randint(100000)}'
-                                      
+
 class HuntsmanCalibsParseTask(CalibsParseTask):
 
     def _translateFromCalibId(self, field, md):

--- a/python/lsst/obs/huntsman/makeHuntsmanRawVisitInfo.py
+++ b/python/lsst/obs/huntsman/makeHuntsmanRawVisitInfo.py
@@ -1,3 +1,11 @@
+"""
+Useful links:
+https://github.com/lsst/obs_base/blob/master/python/lsst/obs/base/makeRawVisitInfo.py
+https://pipelines.lsst.io/modules/lsst.afw.image/exposure-fits-metadata.html
+
+Possibly useful:
+https://jira.lsstcorp.org/browse/DM-19766
+"""
 import numpy as np
 
 from lsst.afw.geom import degrees
@@ -26,4 +34,14 @@ class MakeHuntsmanRawVisitInfo(MakeRawVisitInfo):
         argDict["observatory"] = self.observatory
 
         # This is required to create master darks
-        argDict['darkTime'] = self.getDarkTime(argDict)
+        # argDict['darkTime'] = self.getDarkTime(argDict)
+
+        # This is required by the astrometry code
+        argDict["date"] = self.getDateAvg(md=md, exposureTime=argDict["exposureTime"])
+
+    def getDateAvg(self, md, exposureTime):
+        """
+        Return the date in the middle of the exposure.
+        """
+        dateObs = self.popIsoDate(md, "DATE-OBS")
+        return self.offsetDate(dateObs, 0.5*exposureTime)

--- a/scripts/ingestSkyMapperReference.py
+++ b/scripts/ingestSkyMapperReference.py
@@ -1,0 +1,33 @@
+import os
+import glob
+from lsst.utils import getPackageDir
+from lsst.meas.algorithms import IngestIndexedReferenceTask as ingestTask
+
+
+# Specify the repository
+# This repo itself doesn't matter: it can be any valid butler repository.
+# It just provides something for the Butler to construct itself with.
+rootdir = os.environ["LSST_HOME"]
+repo = os.path.join(rootdir, "DATA")
+
+# Specify the directories
+refcatdir =  os.path.join(rootdir, "testdata", "ref_cats")
+input_glob = os.path.join(refcatdir, "skymapper_test_raw", "*.csv")
+output_dir = os.path.join(refcatdir, "skymapper_test")
+
+# These lines generate the list of files and do the work:
+files = glob.glob(input_glob)
+files.sort()
+
+# Load the config file
+pkgdir = getPackageDir("obs_huntsman")
+configFile = os.path.join(pkgdir, "config", "ingestSkyMapperReference.py")
+config = ingestTask.ConfigClass()
+config.load(configFile)
+
+# Replace `*files` with e.g. `*files[:10]` to only ingest the first 10
+# files, and then run `test_ingested_reference_catalog.py` on the output
+# with a glob pattern that matches the first 10 files to check that the
+# ingest worked.
+args = [repo, "--output", output_dir, *files]
+ingestTask.parseAndRun(args=args, config=config)

--- a/scripts/querySkyMapper.py
+++ b/scripts/querySkyMapper.py
@@ -10,7 +10,7 @@ from astroquery.utils.tap.core import TapPlus
 ra0 = 287.4417
 dec0 = -63.8575
 radius = 4
-g_mag_limit = 17
+g_mag_limit = 16
 class_star_limit = 0.9
 
 # Define the output file name

--- a/scripts/querySkyMapper.py
+++ b/scripts/querySkyMapper.py
@@ -1,0 +1,37 @@
+"""
+Script to run a TAP query on the SkyMapper database.
+"""
+import os
+import pandas as pd
+import matplotlib.pyplot as plt
+from astroquery.utils.tap.core import TapPlus
+
+# Center the query on target
+ra0 = 287.4417
+dec0 = -63.8575
+radius = 4
+g_mag_limit = 17
+class_star_limit = 0.9
+
+# Define the output file name
+output_file = os.path.join(os.environ["OBS_HUNTSMAN_TESTDATA"], "ref_cats",
+                           "skymapper_test_raw", "testcat.csv")
+
+# Define the query
+query = "SELECT * FROM dr3.master"
+query += f" WHERE class_star>{class_star_limit}"
+query += f" AND raj2000>{ra0-radius} AND raj2000<{ra0+radius}"
+query += f" AND dej2000>{dec0-radius} AND dej2000<{dec0+radius}"
+query += f" AND g_psf<{g_mag_limit}"
+
+# Submit the query
+skymapper = TapPlus(url="http://api.skymapper.nci.org.au/aus/tap/")
+job = skymapper.launch_job_async(query, dump_to_file=True, output_format="csv",
+                                 output_file=output_file)
+
+# Make a checkplot
+df = pd.read_csv(output_file)
+plt.figure()
+plt.plot(df["raj2000"], df["dej2000"], "k+", markersize=1)
+plt.plot(ra0, dec0, "ro")
+plt.show(block=False)


### PR DESCRIPTION
Modifications to get `processCcd.py` working, including astrometric & photometric calibration, based on the SkyMapper reference catalogue.  The new functionality includes:

- Improved definition of Huntsman filters
- Serial numbers are stripped from filter names before ingesting
- Code for creating and ingesting the SkyMapper reference catalogue
- Placeholder mapping between SkyMapper and Huntsman filters 
- A simple script to download raw SkyMapper data
- Updated readme and configs