### PR TITLE
Add filter to raw dataId

### DIFF
--- a/policy/HuntsmanMapper.yaml
+++ b/policy/HuntsmanMapper.yaml
@@ -13,7 +13,7 @@ exposures:
   raw:
     python: lsst.afw.image.DecoratedImageU
     persistable: DecoratedImageU
-    template: 'raw/%(dataType)s/%(dateObs)s/%(ccd)i/%(visit)i-%(expId)s.fits'
+    template: 'raw/%(dateObs)s/%(dataType)s/%(filter)s/%(ccd)i/%(visit)i-%(expId)s.fits'
   calexp:
     template: 'calexp/calexp/%(dateObs)s/%(filter)s/%(visit)i-%(expId)s.fits'
   postISRCCD:


### PR DESCRIPTION
This makes it easier to match dataIds to calibIds and appears to be standard practice in obs packages.