### PR TITLE
Change order of `charImage` config overrides

### DIFF
--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -21,11 +21,11 @@ config.isr.doDark = True
 
 # ~~~~~ Characterise image subtask ~~~~
 
-# Load default config
-config.charImage.load(os.path.join(configDir, "characterise.py"))
-
 # Retarget this subtask to use Huntsman override
 config.charImage.retarget(HuntsmanCharacterizeImageTask)
+
+# Load default config
+config.charImage.load(os.path.join(configDir, "characterise.py"))
 
 # Yes we want the outputs to be written to file
 config.charImage.doWrite = True

--- a/policy/HuntsmanMapper.yaml
+++ b/policy/HuntsmanMapper.yaml
@@ -29,7 +29,7 @@ exposures:
     template: calexp/offset-bkgd/%(visit)07d/skyoffset-%(visit)07d_%(ccd)02d-%(filter)s.fits
     level: Ccd
     tables: raw
-    
+
 datasets:
   processCcd_metadata:
     template: 'processCcd_md/%(dateObs)s/processCcd_md-%(visit)04d-%(filter)s-%(ccd)02d.boost'

--- a/python/lsst/obs/huntsman/HuntsmanMapper.py
+++ b/python/lsst/obs/huntsman/HuntsmanMapper.py
@@ -6,9 +6,6 @@ from lsst.obs.base import CameraMapper
 from .makeHuntsmanRawVisitInfo import MakeHuntsmanRawVisitInfo
 from .huntsmanFilters import HUNTSMAN_FILTER_DEFINITIONS
 
-import traceback
-from lsst.obs.base.utils import createInitialSkyWcs, InitialSkyWcsError
-
 
 class HuntsmanMapper(CameraMapper):
 


### PR DESCRIPTION
On the assumption that the retarget should happen before any other config options are specified.